### PR TITLE
reveal number panel neighbors on "both buttons clicked"

### DIFF
--- a/BlazorGames/Models/Minesweeper/GameBoard.cs
+++ b/BlazorGames/Models/Minesweeper/GameBoard.cs
@@ -73,6 +73,19 @@ namespace BlazorGames.Models.Minesweeper
             return nearbyPanels.Except(currentPanel).ToList();
         }
 
+        public void RevealNumberPanelNeighbors(int x, int y)
+        {
+            var neighbors = GetNeighbors(x, y);
+
+            foreach (var panel in neighbors)
+            {
+                if (!panel.IsFlagged && !panel.IsRevealed)
+                {
+                    RevealPanel(panel.X, panel.Y);
+                }
+            }
+        }
+
         public void RevealPanel(int x, int y)
         {
             //Step 1: Find and reveal the clicked panel

--- a/BlazorGames/Pages/Minesweeper.razor
+++ b/BlazorGames/Pages/Minesweeper.razor
@@ -30,6 +30,18 @@
 
         await _jsRuntime.InvokeVoidAsync("Prism.highlightAll");
     }
+
+    bool leftButtonPressed = false;
+    bool rightButtonPressed = false;
+
+    private bool BothButtonsPressed => leftButtonPressed && rightButtonPressed;
+
+    private void NumberPanelMouseUpHandler(int x, int y)
+    {
+        if (BothButtonsPressed) board.RevealNumberPanelNeighbors(x, y);
+        leftButtonPressed = false;
+        rightButtonPressed = false;
+    }
 }
 
 <PageTitle Title="Minesweeper" />
@@ -114,7 +126,7 @@
                         }
                         else //Number
                         {
-                            <div class="minesweeper-gamepiece minesweeper-@currentPanel.AdjacentMines">@currentPanel.AdjacentMines</div>
+                            <div class="minesweeper-gamepiece minesweeper-@currentPanel.AdjacentMines" @onmousedown="@(e => { if (e.Button == 0) leftButtonPressed = true; if (e.Button == 2) rightButtonPressed = true; })" @onmouseup="@(() => NumberPanelMouseUpHandler(x, y))">@currentPanel.AdjacentMines</div>
                         }
                     }
                     else if (currentPanel.IsFlagged)


### PR DESCRIPTION
In the original minesweeper game, there is a feature that is very practical and time saving but few people knows about it : when both mouse buttons are pressed at the same time and then released, it reveals every neighboring panels that are not flagged.

For instance, in this situation:

![image](https://github.com/exceptionnotfound/BlazorGames/assets/11414291/c729d1e6-38a3-40fe-92ed-469aeee8a18a)

We can be certain that there are no mines left around the "1" that is on the left side of the flag. Instead of clicking on each of the three panels under it, we can just press the two mouse buttons at the same time on the "1" panel and when we release at least one button the three panels under it are revealed:

![image](https://github.com/exceptionnotfound/BlazorGames/assets/11414291/00f5a1ef-3b70-4888-9cd6-7ab07257bb3a)

Obviously, if there is a mine under a panel that is not marked with a flag, you will still loose the game if you click on it this way.

In this PR I slighly modified the code to permit the "both buttons clicked" feature.
